### PR TITLE
Support carriage returns in escape_converter

### DIFF
--- a/lib/js_regex/converter/escape_converter.rb
+++ b/lib/js_regex/converter/escape_converter.rb
@@ -13,7 +13,8 @@ class JsRegex
         case subtype
         when :backslash, :codepoint, :form_feed, :return, :hex, :interval_close,
              :interval_open, :newline, :one_or_more, :octal, :space, :set_close,
-             :set_open, :dot, :tab, :vertical_tab, :zero_or_more, :zero_or_one
+             :set_open, :dot, :tab, :vertical_tab, :zero_or_more, :zero_or_one,
+             :carriage
           pass_through
         when :literal
           LiteralConverter.convert(data, self)

--- a/spec/js_regex/converter/escape_sequence_handling_spec.rb
+++ b/spec/js_regex/converter/escape_sequence_handling_spec.rb
@@ -149,5 +149,12 @@ describe JsRegex::Converter do
       expect_js_regex_to_be(/(a)/)
       expect_warning
     end
+
+    it 'preservers carriage returns' do
+      given_the_ruby_regexp(/\r/)
+      expect_js_regex_to_be(/\r/)
+      expect_no_warnings
+      expect_ruby_and_js_to_match(string: "abc\r123", with_results: ["\r"])
+    end
   end
 end


### PR DESCRIPTION
Hi there,

I'm using your library for a project at work and noticed that it was throwing an error when trying to parse a Ruby RegExp containing `/r`.

This is valid in JS RegExps, but was erroneously being blacklisted. So I've just created a little PR to amend this.

Also – this is my first Ruby PR so apologies if it's lacking anything!

Thanks,
Marc