### PR TITLE
Preserve escaped match groups

### DIFF
--- a/lib/js_regex/converter/escape_converter.rb
+++ b/lib/js_regex/converter/escape_converter.rb
@@ -19,6 +19,8 @@ class JsRegex
         :dot,
         :eol,
         :form_feed,
+        :group_close,
+        :group_open,
         :hex,
         :interval_close,
         :interval_open,

--- a/spec/lib/js_regex/converter/escape_converter_spec.rb
+++ b/spec/lib/js_regex/converter/escape_converter_spec.rb
@@ -20,6 +20,13 @@ describe JsRegex::Converter::EscapeConverter do
     expect_ruby_and_js_to_match(string: '\\', with_results: %w(\\))
   end
 
+  it 'preserves escaped groups' do
+    given_the_ruby_regexp(/\(1\)/)
+    expect_js_regex_to_be(/\(1\)/)
+    expect_no_warnings
+    expect_ruby_and_js_to_match(string: '(1)', with_results: ["(1)"])
+  end
+
   it 'preserves escaped literals' do
     given_the_ruby_regexp(/\j/)
     expect_js_regex_to_be(/\j/)


### PR DESCRIPTION
Currently, a regex such as `/\(0\)/` is translated to `/(0)/`. This PR fixes that, as JS regex can handle escaped match groups.